### PR TITLE
PIPE2D-995: Make ModelInterpolation use WavelengthArray

### DIFF
--- a/python/pfs/drp/fstar/modelInterpolation.py
+++ b/python/pfs/drp/fstar/modelInterpolation.py
@@ -1,3 +1,5 @@
+from pfs.datamodel.wavelengthArray import WavelengthArray
+
 import numpy as np
 from . import parallel
 
@@ -27,7 +29,7 @@ class ModelInterpolation:
 
         start = wcs["CRVAL1"] + wcs["CDELT1"] * (1 - wcs["CRPIX1"])
         stop = wcs["CRVAL1"] + wcs["CDELT1"] * (len(model) - wcs["CRPIX1"])
-        self.wavelength = np.linspace(start, stop, num=len(model), endpoint=True, dtype=float)
+        self.wavelength = WavelengthArray(start, stop, len(model), dtype=float)
 
     @classmethod
     def fromFluxModelData(cls, path):
@@ -90,7 +92,7 @@ class ModelInterpolation:
 
         Returns
         -------
-        wavelength : `numpy.ndarray`
+        wavelength : `pfs.datamodel.wavelengthArray.WavelengthArray`
             Wavelength in nm.
         spectrum : `numpy.ndarray`
             Interpolation spectrum.
@@ -101,4 +103,6 @@ class ModelInterpolation:
             return interpolatedFlux
         spectrum = parallel.parallel_map(doInterpolation, self.model, n_procs=nProcs)
 
-        return np.copy(self.wavelength), np.asarray(spectrum)
+        # We don't make a copy of self.wavelength
+        # because it is readonly.
+        return self.wavelength, np.asarray(spectrum)

--- a/tests/test_modelInterpolation.py
+++ b/tests/test_modelInterpolation.py
@@ -1,4 +1,5 @@
 from pfs.drp.fstar.modelInterpolation import ModelInterpolation
+from pfs.datamodel.wavelengthArray import WavelengthArray
 import lsst.utils
 import lsst.utils.tests
 
@@ -17,6 +18,7 @@ class ModelInterpolationTestCase(lsst.utils.tests.TestCase):
 
         model = ModelInterpolation.fromFluxModelData(dataDir)
         wavelength, flux = model.interpolate(teff=7777, logg=3.333, metal=0.555, alpha=0.222)
+        self.assertIsInstance(wavelength, WavelengthArray)
         self.assertEqual(len(wavelength.shape), 1)
         self.assertEqual(wavelength.shape, flux.shape)
 

--- a/ups/drp_fstar.table
+++ b/ups/drp_fstar.table
@@ -1,5 +1,6 @@
 setupRequired(sconsUtils)
 setupRequired(utils)
+setupRequired(datamodel)
 setupOptional(fluxmodeldata)
 
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
ModelInterpolation class now uses pfs.datamodel.wavelength.WavelengthArray.
With this change, this package comes to require datamodel package.